### PR TITLE
[include-cleaner] Treat include_next as exporting

### DIFF
--- a/clang-tools-extra/include-cleaner/unittests/RecordTest.cpp
+++ b/clang-tools-extra/include-cleaner/unittests/RecordTest.cpp
@@ -452,6 +452,8 @@ TEST_F(PragmaIncludeTest, IWYUExportForStandardHeaders) {
   auto &FM = Processed.fileManager();
   EXPECT_THAT(PI.getExporters(*tooling::stdlib::Header::named("<string>"), FM),
               testing::UnorderedElementsAre(FileNamed("export.h")));
+  EXPECT_THAT(PI.getExporters(llvm::cantFail(FM.getFileRef("string")), FM),
+              testing::UnorderedElementsAre(FileNamed("export.h")));
 }
 
 TEST_F(PragmaIncludeTest, IWYUExportBlock) {


### PR DESCRIPTION
Most of the time the included-header cannot be just `#include`d from
user code, and providing findings asking for the inclusion of the inner
header seems wrong.

We have enough explicit intent from the developer around included header
and including header being related via use of include_next directive,
instead of a regular include.

So this patch proposes to treat the inner header as being exported so
that the user can only include the outer header. This also works nicely
when the user is transitively relying on inner header, we'll still
suggest including that one and if the spelling of inner and outer
headers are different that inclusion will be correct. Otherwise if the
spellings are the same, we'll treat the outer header as the provider.
